### PR TITLE
Fix factory for caret margin.

### DIFF
--- a/OverviewMargin/CaretMargin/CaretMarginFactory.cs
+++ b/OverviewMargin/CaretMargin/CaretMarginFactory.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Extensions.CaretMargin
         [Export]
         [Name("CaretAdornmentLayer")]
         [Order(After = PredefinedAdornmentLayers.Outlining, Before = PredefinedAdornmentLayers.Selection)]
-        //internal AdornmentLayerDefinition caretLayerDefinition;
+        internal AdornmentLayerDefinition caretLayerDefinition;
 
         public bool LoadOption(IEditorOptions options, string optionName)
         {


### PR DESCRIPTION
This might fix the following error, appearing when starting visual studio with the extension installed:
![2017-01-13 14_17_18-microsoft visual studio](https://cloud.githubusercontent.com/assets/25102076/21931781/97077a78-d99d-11e6-979b-69797e761a78.png)
